### PR TITLE
Fix for failure with geth 1.5.0 (web3.eth.coinbase throws exception)

### DIFF
--- a/gethdev.js
+++ b/gethdev.js
@@ -63,7 +63,7 @@
   // web3.eth.coinbase may be undefined or throw an exception, thus handling both cases here
   try {
     var coinbase = web3.eth.coinbase;
-    if (!web3.eth.coinbase) {
+    if (!coinbase) {
       throw "undefined"
     }
   } catch(e) {

--- a/gethdev.js
+++ b/gethdev.js
@@ -60,7 +60,13 @@
   }
 
   // create the first account (with blank password) if necessary
-  if (!web3.eth.coinbase) {
+  // web3.eth.coinbase may be undefined or throw an exception, thus handling both cases here
+  try {
+    var coinbase = web3.eth.coinbase;
+    if (!web3.eth.coinbase) {
+      throw "undefined"
+    }
+  } catch(e) {
     log('Creating etherbase account');
     web3.personal.newAccount('');
   }


### PR DESCRIPTION
I'm running geth 1.5.0-unstable-f130c5d3.
gethdev fails with

```
Fatal: Failed to execute /home/didi/dev-tools/node_4.4.3/lib/node_modules/gethdev/gethdev.js: etherbase address must be explicitly specified
```

I could track this down to an exception being thrown by web3.eth.coinbase when no account exists:

```
     > web3.eth.coinbase
etherbase address must be explicitly specified
    at web3.js:3119:20                                                                                                                                                                       
    at web3.js:6023:15                                                                                                                                                                       
    at get (web3.js:5923:38)                                                                                                                                                                 
    at <anonymous>:1:-1 
```

Provided is a fix which works for both the old and new behaviour.
